### PR TITLE
Filter NFL games by current season

### DIFF
--- a/api/src/modules/games/games.service.spec.ts
+++ b/api/src/modules/games/games.service.spec.ts
@@ -49,6 +49,92 @@ describe('GamesService', () => {
     expect(service).toBeDefined();
   });
 
+  describe('getCurrentSeasonRange', () => {
+    it('should calculate 2025 season if today is February 15, 2026 (before April 1)', () => {
+      const today = new Date(2026, 1, 15); // February 15, 2026 (0-indexed month: 1 = Feb)
+      const range = service.getCurrentSeasonRange(today);
+      expect(range.season).toBe(2025);
+      expect(range.start).toEqual(new Date(2025, 3, 1, 0, 0, 0, 0)); // April 1, 2025
+      expect(range.end).toEqual(new Date(2026, 2, 31, 23, 59, 59, 999)); // March 31, 2026
+    });
+
+    it('should calculate 2026 season if today is June 20, 2026 (after April 1)', () => {
+      const today = new Date(2026, 5, 20); // June 20, 2026 (0-indexed month: 5 = June)
+      const range = service.getCurrentSeasonRange(today);
+      expect(range.season).toBe(2026);
+      expect(range.start).toEqual(new Date(2026, 3, 1, 0, 0, 0, 0)); // April 1, 2026
+      expect(range.end).toEqual(new Date(2027, 2, 31, 23, 59, 59, 999)); // March 31, 2027
+    });
+
+    it('should calculate 2026 season on the start boundary of April 1, 2026', () => {
+      const today = new Date(2026, 3, 1, 12, 0, 0); // April 1, 2026
+      const range = service.getCurrentSeasonRange(today);
+      expect(range.season).toBe(2026);
+      expect(range.start).toEqual(new Date(2026, 3, 1, 0, 0, 0, 0));
+    });
+
+    it('should calculate 2025 season on the end boundary of March 31, 2026', () => {
+      const today = new Date(2026, 2, 31, 23, 59, 59); // March 31, 2026
+      const range = service.getCurrentSeasonRange(today);
+      expect(range.season).toBe(2025);
+      expect(range.end).toEqual(new Date(2026, 2, 31, 23, 59, 59, 999));
+    });
+  });
+
+  describe('getGames with filtering', () => {
+    it('should only return games that are within the current season range', async () => {
+      const today = new Date(2026, 1, 15); // Season 2025: April 1, 2025 to March 31, 2026
+
+      const mockGamesDocs = [
+        {
+          id: 'game-1',
+          data: () => ({
+            season: 2025,
+            awayTeam: 'ARI',
+            homeTeam: 'ATL',
+            kickoffTime: { toDate: () => new Date(2025, 8, 10, 13, 0) }, // In-season
+            week: 1,
+            winner: null,
+          }),
+        },
+        {
+          id: 'game-2',
+          data: () => ({
+            season: 2024,
+            awayTeam: 'DAL',
+            homeTeam: 'NYG',
+            kickoffTime: { toDate: () => new Date(2024, 8, 10, 13, 0) }, // Out of season (too early)
+            week: 1,
+            winner: 'DAL',
+          }),
+        },
+        {
+          id: 'game-3',
+          data: () => ({
+            season: 2026,
+            awayTeam: 'KC',
+            homeTeam: 'SF',
+            kickoffTime: { toDate: () => new Date(2026, 8, 10, 13, 0) }, // Out of season (too late)
+            week: 1,
+            winner: null,
+          }),
+        },
+      ];
+
+      mockFirestore.collection.mockReturnValue({
+        get: mockFirestore.get.mockResolvedValue({
+          docs: mockGamesDocs,
+        }),
+      } as any);
+
+      const games = await service.getGames(today);
+
+      expect(games).toHaveLength(1);
+      expect((games[0] as any).id).toBe('game-1');
+      expect(games[0].season).toBe(2025);
+    });
+  });
+
   describe('checkForEndedGames', () => {
     it('should do nothing if no games are found', async () => {
       mockFirestore.collection.mockReturnValue({

--- a/api/src/modules/games/games.service.ts
+++ b/api/src/modules/games/games.service.ts
@@ -15,9 +15,19 @@ export class GamesService {
     private readonly logger: Logger
   ) {}
 
-  async getGames(): Promise<GameDto[]> {
+  getCurrentSeasonRange(today: Date = new Date()): { start: Date; end: Date; season: number } {
+    const year = today.getFullYear();
+    const month = today.getMonth(); // 0-indexed: 0 = Jan, 1 = Feb, 2 = Mar, 3 = Apr
+    const seasonYear = month < 3 ? year - 1 : year;
+    const start = new Date(seasonYear, 3, 1, 0, 0, 0, 0);
+    const end = new Date(seasonYear + 1, 2, 31, 23, 59, 59, 999);
+    return { start, end, season: seasonYear };
+  }
+
+  async getGames(today: Date = new Date()): Promise<GameDto[]> {
+    const { start, end } = this.getCurrentSeasonRange(today);
     const snapshot = await admin.firestore().collection('games').get();
-    return snapshot.docs.map((doc) => {
+    const allGames = snapshot.docs.map((doc) => {
       const data = doc.data();
       return {
         id: doc.id,
@@ -30,6 +40,12 @@ export class GamesService {
         week: data.week,
         winner: data.winner ?? null,
       };
+    });
+
+    return allGames.filter((game) => {
+      if (!game.kickoffTime) return false;
+      const kickoffDate = new Date(game.kickoffTime);
+      return kickoffDate >= start && kickoffDate <= end;
     });
   }
 


### PR DESCRIPTION
This PR updates GamesService.getGames() to return only the games belonging to the current season, which starts on April 1 and ends on March 31. Leaderboard logic and other dependent features will automatically respect this current season configuration. Full unit test coverage is added for the season boundary calculation and filtering logic.

---
*PR created automatically by Jules for task [4260485087678148232](https://jules.google.com/task/4260485087678148232) started by @joshknopp*