### PR TITLE
Add user active state management for new season reset

### DIFF
--- a/api/src/app/user.controller.ts
+++ b/api/src/app/user.controller.ts
@@ -26,7 +26,7 @@ export class UserController {
     description: 'Unauthorized. Bearer token missing or invalid.',
   })
   async getUser(@Req() req) {
-    const uid = req.user?.uid || req.user?.id;
+    const uid = req.user?.uid;
     if (uid) {
       await this.userService.activateUser(uid);
     }
@@ -37,7 +37,7 @@ export class UserController {
   @Get('username')
   @ApiOperation({ summary: 'Get the username for the logged-in user' })
   async getUsername(@Req() req) {
-    const uid = req.user?.uid || req.user?.id;
+    const uid = req.user?.uid;
     if (!uid) return { error: 'No user found' };
     const username = await this.userService.getUsername(uid);
     return { username };
@@ -47,7 +47,7 @@ export class UserController {
   @Put('username')
   @ApiOperation({ summary: 'Set the username for the logged-in user' })
   async setUsername(@Req() req, @Body('username') username: string) {
-    const uid = req.user?.uid || req.user?.id;
+    const uid = req.user?.uid;
     if (!uid) return { error: 'No user found' };
     if (!username || username.length < 3 || username.length > 20) {
       return { error: 'Username must be 3-20 characters.' };
@@ -60,7 +60,7 @@ export class UserController {
   @Post('activate')
   @ApiOperation({ summary: 'Activate the authenticated user' })
   async activateUser(@Req() req) {
-    const uid = req.user?.uid || req.user?.id;
+    const uid = req.user?.uid;
     if (!uid) return { error: 'No user found' };
     await this.userService.activateUser(uid);
     return { success: true };

--- a/api/src/app/user.controller.ts
+++ b/api/src/app/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Put, Req, Body, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Put, Req, Body, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -25,7 +25,11 @@ export class UserController {
     status: 401,
     description: 'Unauthorized. Bearer token missing or invalid.',
   })
-  getUser(@Req() req) {
+  async getUser(@Req() req) {
+    const uid = req.user?.uid || req.user?.id;
+    if (uid) {
+      await this.userService.activateUser(uid);
+    }
     return req.user;
   }
 
@@ -33,7 +37,7 @@ export class UserController {
   @Get('username')
   @ApiOperation({ summary: 'Get the username for the logged-in user' })
   async getUsername(@Req() req) {
-    const uid = req.user?.uid;
+    const uid = req.user?.uid || req.user?.id;
     if (!uid) return { error: 'No user found' };
     const username = await this.userService.getUsername(uid);
     return { username };
@@ -43,12 +47,29 @@ export class UserController {
   @Put('username')
   @ApiOperation({ summary: 'Set the username for the logged-in user' })
   async setUsername(@Req() req, @Body('username') username: string) {
-    const uid = req.user?.uid;
+    const uid = req.user?.uid || req.user?.id;
     if (!uid) return { error: 'No user found' };
     if (!username || username.length < 3 || username.length > 20) {
       return { error: 'Username must be 3-20 characters.' };
     }
     await this.userService.setUsername(uid, username);
     return { success: true };
+  }
+
+  @UseGuards(AuthGuard)
+  @Post('activate')
+  @ApiOperation({ summary: 'Activate the authenticated user' })
+  async activateUser(@Req() req) {
+    const uid = req.user?.uid || req.user?.id;
+    if (!uid) return { error: 'No user found' };
+    await this.userService.activateUser(uid);
+    return { success: true };
+  }
+
+  @UseGuards(AuthGuard)
+  @Post('deactivate-all')
+  @ApiOperation({ summary: 'Deactivate all users (clean slate for new season)' })
+  async deactivateAllUsers() {
+    return await this.userService.deactivateAllUsers();
   }
 }

--- a/api/src/app/user.service.spec.ts
+++ b/api/src/app/user.service.spec.ts
@@ -1,0 +1,159 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserService } from './user.service';
+import * as admin from 'firebase-admin';
+
+const mockDoc = {
+  get: jest.fn(),
+  set: jest.fn(),
+};
+
+const mockCollection = {
+  doc: jest.fn(() => mockDoc),
+  get: jest.fn(),
+};
+
+const mockBatch = {
+  set: jest.fn(),
+  commit: jest.fn(),
+};
+
+jest.mock('firebase-admin', () => ({
+  initializeApp: jest.fn(),
+  firestore: () => ({
+    collection: jest.fn(() => mockCollection),
+    batch: jest.fn(() => mockBatch),
+  }),
+}));
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserService],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('activateUser', () => {
+    it('should set isActive to true on the user document', async () => {
+      mockDoc.set.mockResolvedValue(undefined);
+
+      await service.activateUser('user-123');
+
+      expect(mockCollection.doc).toHaveBeenCalledWith('user-123');
+      expect(mockDoc.set).toHaveBeenCalledWith(
+        { isActive: true },
+        { merge: true }
+      );
+    });
+  });
+
+  describe('getUsername', () => {
+    it('should auto-activate user if document does not exist and return null', async () => {
+      mockDoc.get
+        .mockResolvedValueOnce({
+          exists: false,
+          data: () => undefined,
+        })
+        .mockResolvedValueOnce({
+          exists: true,
+          data: () => ({ isActive: true }),
+        });
+      mockDoc.set.mockResolvedValue(undefined);
+
+      const username = await service.getUsername('user-123');
+
+      expect(mockDoc.set).toHaveBeenCalledWith(
+        { isActive: true },
+        { merge: true }
+      );
+      expect(username).toBeNull();
+    });
+
+    it('should return username and not re-activate if user is already active', async () => {
+      mockDoc.get.mockResolvedValue({
+        exists: true,
+        data: () => ({ username: 'TestUser', isActive: true }),
+      });
+
+      const username = await service.getUsername('user-123');
+
+      expect(mockDoc.set).not.toHaveBeenCalled();
+      expect(username).toBe('TestUser');
+    });
+
+    it('should activate user and return username if user document exists but isActive is missing or false', async () => {
+      mockDoc.get
+        .mockResolvedValueOnce({
+          exists: true,
+          data: () => ({ username: 'InactiveUser', isActive: false }),
+        })
+        .mockResolvedValueOnce({
+          exists: true,
+          data: () => ({ username: 'InactiveUser', isActive: true }),
+        });
+      mockDoc.set.mockResolvedValue(undefined);
+
+      const username = await service.getUsername('user-123');
+
+      expect(mockDoc.set).toHaveBeenCalledWith(
+        { isActive: true },
+        { merge: true }
+      );
+      expect(username).toBe('InactiveUser');
+    });
+  });
+
+  describe('setUsername', () => {
+    it('should set username and isActive to true', async () => {
+      mockDoc.set.mockResolvedValue(undefined);
+
+      await service.setUsername('user-123', 'NewUsername');
+
+      expect(mockCollection.doc).toHaveBeenCalledWith('user-123');
+      expect(mockDoc.set).toHaveBeenCalledWith(
+        { username: 'NewUsername', isActive: true },
+        { merge: true }
+      );
+    });
+  });
+
+  describe('deactivateAllUsers', () => {
+    it('should return 0 deactivated count if users collection is empty', async () => {
+      mockCollection.get.mockResolvedValue({
+        empty: true,
+        docs: [],
+        size: 0,
+      });
+
+      const result = await service.deactivateAllUsers();
+
+      expect(result).toEqual({ deactivatedCount: 0 });
+    });
+
+    it('should set isActive to false on all user documents in batch', async () => {
+      const doc1Ref = { id: 'user-1' };
+      const doc2Ref = { id: 'user-2' };
+      mockCollection.get.mockResolvedValue({
+        empty: false,
+        size: 2,
+        docs: [{ ref: doc1Ref }, { ref: doc2Ref }],
+      });
+      mockBatch.commit.mockResolvedValue(undefined);
+
+      const result = await service.deactivateAllUsers();
+
+      expect(mockBatch.set).toHaveBeenCalledWith(doc1Ref, { isActive: false }, { merge: true });
+      expect(mockBatch.set).toHaveBeenCalledWith(doc2Ref, { isActive: false }, { merge: true });
+      expect(mockBatch.commit).toHaveBeenCalled();
+      expect(result).toEqual({ deactivatedCount: 2 });
+    });
+  });
+});

--- a/api/src/app/user.service.ts
+++ b/api/src/app/user.service.ts
@@ -5,14 +5,36 @@ import * as admin from 'firebase-admin';
 export class UserService {
   private usersCollection = admin.firestore().collection('users');
 
+  async activateUser(uid: string): Promise<void> {
+    await this.usersCollection.doc(uid).set({ isActive: true }, { merge: true });
+  }
+
   async getUsername(uid: string): Promise<string | null> {
-    const doc = await this.usersCollection.doc(uid).get();
-    if (!doc.exists) return null;
-    const data = doc.data();
+    const docRef = this.usersCollection.doc(uid);
+    const doc = await docRef.get();
+    let data = doc.data();
+    if (!doc.exists || data?.isActive !== true) {
+      await docRef.set({ isActive: true }, { merge: true });
+      const updatedDoc = await docRef.get();
+      data = updatedDoc.data();
+    }
     return data?.username || null;
   }
 
   async setUsername(uid: string, username: string): Promise<void> {
-    await this.usersCollection.doc(uid).set({ username }, { merge: true });
+    await this.usersCollection.doc(uid).set({ username, isActive: true }, { merge: true });
+  }
+
+  async deactivateAllUsers(): Promise<{ deactivatedCount: number }> {
+    const snapshot = await this.usersCollection.get();
+    if (snapshot.empty) return { deactivatedCount: 0 };
+
+    const batch = admin.firestore().batch();
+    snapshot.docs.forEach((doc) => {
+      batch.set(doc.ref, { isActive: false }, { merge: true });
+    });
+    await batch.commit();
+
+    return { deactivatedCount: snapshot.size };
   }
 }

--- a/api/src/modules/leaderboard/leaderboard.service.spec.ts
+++ b/api/src/modules/leaderboard/leaderboard.service.spec.ts
@@ -1,0 +1,114 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeaderboardService } from './leaderboard.service';
+import { GamesService } from '../games/games.service';
+import { PicksService } from '../picks/picks.service';
+import * as admin from 'firebase-admin';
+
+const mockFirestore = {
+  collection: jest.fn(),
+};
+
+const mockListUsers = jest.fn();
+
+jest.mock('firebase-admin', () => ({
+  initializeApp: jest.fn(),
+  firestore: () => mockFirestore,
+  auth: () => ({
+    listUsers: mockListUsers,
+  }),
+}));
+
+describe('LeaderboardService', () => {
+  let service: LeaderboardService;
+
+  const mockGamesService = {
+    getGames: jest.fn(),
+  };
+
+  const mockPicksService = {
+    getLeaguePicks: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LeaderboardService,
+        { provide: GamesService, useValue: mockGamesService },
+        { provide: PicksService, useValue: mockPicksService },
+      ],
+    }).compile();
+
+    service = module.get<LeaderboardService>(LeaderboardService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getLeaderboard', () => {
+    it('should only include active users (isActive === true) in leaderboard', async () => {
+      // Setup mock Auth users
+      mockListUsers.mockResolvedValue({
+        users: [
+          { uid: 'user-active', email: 'active@test.com', displayName: 'Active User' },
+          { uid: 'user-inactive', email: 'inactive@test.com', displayName: 'Inactive User' },
+          { uid: 'user-missing', email: 'missing@test.com', displayName: 'Missing Field User' },
+        ],
+      });
+
+      // Setup mock Firestore users collection
+      const mockUserDocs = [
+        {
+          id: 'user-active',
+          data: () => ({ username: 'ActivePlayer', isActive: true }),
+        },
+        {
+          id: 'user-inactive',
+          data: () => ({ username: 'InactivePlayer', isActive: false }),
+        },
+        {
+          id: 'user-missing',
+          data: () => ({ username: 'MissingPlayer' }), // missing isActive
+        },
+      ];
+
+      mockFirestore.collection.mockReturnValue({
+        get: jest.fn().mockResolvedValue({
+          forEach: (cb: (doc: any) => void) => mockUserDocs.forEach(cb),
+        }),
+      });
+
+      // Setup mock games and picks
+      mockGamesService.getGames.mockResolvedValue([
+        {
+          season: 2025,
+          week: 1,
+          awayTeam: 'KC',
+          homeTeam: 'BAL',
+          kickoffTime: new Date().toISOString(),
+          winner: 'KC',
+        },
+      ]);
+
+      mockPicksService.getLeaguePicks.mockResolvedValue([
+        {
+          season: 2025,
+          week: 1,
+          awayTeam: 'KC',
+          homeTeam: 'BAL',
+          pickWinner: 'KC',
+          user: 'user-active',
+        },
+      ]);
+
+      const result = await service.getLeaderboard(1, { id: 'user-active', email: 'active@test.com' });
+
+      expect(result.week).toBe(1);
+      expect(result.leaderboard).toHaveLength(1);
+      expect(result.leaderboard[0].user.uid).toBe('user-active');
+      expect(result.leaderboard[0].user.displayName).toBe('ActivePlayer');
+    });
+  });
+});

--- a/api/src/modules/leaderboard/leaderboard.service.ts
+++ b/api/src/modules/leaderboard/leaderboard.service.ts
@@ -22,18 +22,24 @@ export class LeaderboardService {
       .sort((a, b) => a.kickoffTime.localeCompare(b.kickoffTime));
     const picks = await this.picksService.getLeaguePicks();
 
-    // Fetch usernames from Firestore for all users
+    // Fetch usernames and active state from Firestore for all users
     const usernameMap: Record<string, string> = {};
+    const activeUserIds = new Set<string>();
     const db = admin.firestore();
     const userDocs = await db.collection('users').get();
     userDocs.forEach((doc) => {
       const data = doc.data();
+      if (data?.isActive === true) {
+        activeUserIds.add(doc.id);
+      }
       if (data?.username) {
         usernameMap[doc.id] = data.username;
       }
     });
 
-    const leaderboard = users.map((user) => {
+    const activeUsers = users.filter((user) => activeUserIds.has(user.uid));
+
+    const leaderboard = activeUsers.map((user) => {
       const userPicks = picks.filter((pick) => pick.user === user.uid);
       const { wins, losses } = this.calculateWinLoss(userPicks, games);
       // Use username if available, else displayName, else email

--- a/frontend/src/app/admin/admin.component.ts
+++ b/frontend/src/app/admin/admin.component.ts
@@ -12,8 +12,11 @@ import { ApiService } from '../api.service';
 export class AdminComponent {
   private apiService = inject(ApiService);
   isUpdating = false;
+  isDeactivating = false;
   updatedGamesCount: number | null = null;
+  deactivatedUsersCount: number | null = null;
   error: string | null = null;
+  deactivateSuccessMessage: string | null = null;
 
   updateWinners(): void {
     if (this.isUpdating) return;
@@ -22,7 +25,7 @@ export class AdminComponent {
     this.updatedGamesCount = null;
     this.error = null;
 
-    this.apiService.post('/games/check-ended', {}).subscribe({
+    this.apiService.post('games/check-ended', {}).subscribe({
       next: (result: any[]) => {
         this.updatedGamesCount = result.length;
         this.isUpdating = false;
@@ -31,6 +34,35 @@ export class AdminComponent {
         this.error = 'Failed to update winners: ' + (error.message || 'Unknown error');
         console.error('Failed to update winners', error);
         this.isUpdating = false;
+      },
+    });
+  }
+
+  deactivateAllUsers(): void {
+    if (this.isDeactivating) return;
+    if (
+      !confirm(
+        'Are you sure you want to set all users to inactive? Users will become active upon logging in.'
+      )
+    ) {
+      return;
+    }
+
+    this.isDeactivating = true;
+    this.deactivateSuccessMessage = null;
+    this.error = null;
+
+    this.apiService.post('user/deactivate-all', {}).subscribe({
+      next: (result: { deactivatedCount: number }) => {
+        this.deactivatedUsersCount = result.deactivatedCount;
+        this.deactivateSuccessMessage = `Successfully deactivated ${result.deactivatedCount} users.`;
+        this.isDeactivating = false;
+      },
+      error: (error: any) => {
+        this.error =
+          'Failed to deactivate users: ' + (error.message || 'Unknown error');
+        console.error('Failed to deactivate users', error);
+        this.isDeactivating = false;
       },
     });
   }

--- a/frontend/src/app/admin/admin.css
+++ b/frontend/src/app/admin/admin.css
@@ -1,0 +1,6 @@
+.admin-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}

--- a/frontend/src/app/admin/admin.html
+++ b/frontend/src/app/admin/admin.html
@@ -1,19 +1,38 @@
 <div class="admin-container">
   <h2>Admin Panel</h2>
   <p>This is the admin panel. Here you can perform administrative tasks.</p>
-  <button
-    class="btn btn-primary"
-    (click)="updateWinners()"
-    [disabled]="isUpdating"
-  >
-    <span *ngIf="!isUpdating">Update Winners</span>
-    <span *ngIf="isUpdating">
-      <span class="spinner-sm"></span>
-      Updating...
-    </span>
-  </button>
+
+  <div class="admin-actions">
+    <button
+      class="btn btn-primary"
+      (click)="updateWinners()"
+      [disabled]="isUpdating"
+    >
+      <span *ngIf="!isUpdating">Update Winners</span>
+      <span *ngIf="isUpdating">
+        <span class="spinner-sm"></span>
+        Updating...
+      </span>
+    </button>
+
+    <button
+      class="btn btn-secondary"
+      (click)="deactivateAllUsers()"
+      [disabled]="isDeactivating"
+    >
+      <span *ngIf="!isDeactivating">Deactivate All Users (New Season)</span>
+      <span *ngIf="isDeactivating">
+        <span class="spinner-sm"></span>
+        Deactivating...
+      </span>
+    </button>
+  </div>
+
   <div *ngIf="updatedGamesCount !== null" class="success-message">
     Successfully updated {{ updatedGamesCount }} games.
+  </div>
+  <div *ngIf="deactivateSuccessMessage" class="success-message">
+    {{ deactivateSuccessMessage }}
   </div>
   <div *ngIf="error" class="error-message">
     {{ error }}

--- a/scripts/deactivate-all-users.js
+++ b/scripts/deactivate-all-users.js
@@ -1,0 +1,43 @@
+// Node.js script to set all user records in the Firestore 'users' collection to inactive (isActive: false)
+
+const admin = require('firebase-admin');
+
+// Initialize Firebase Admin SDK
+if (!admin.apps.length) {
+  try {
+    const serviceAccount = require('../api/serviceAccountKey.json');
+    admin.initializeApp({
+      credential: admin.credential.cert(serviceAccount),
+    });
+  } catch (e) {
+    admin.initializeApp({
+      credential: admin.credential.applicationDefault(),
+    });
+  }
+}
+
+const db = admin.firestore();
+
+async function deactivateAllUsers() {
+  console.log('Deactivating all users in Firestore...');
+  const usersCollection = db.collection('users');
+  const snapshot = await usersCollection.get();
+
+  if (snapshot.empty) {
+    console.log('No user documents found in Firestore.');
+    return;
+  }
+
+  const batch = db.batch();
+  snapshot.docs.forEach((doc) => {
+    batch.set(doc.ref, { isActive: false }, { merge: true });
+  });
+
+  await batch.commit();
+  console.log(`Successfully deactivated ${snapshot.size} user document(s).`);
+}
+
+deactivateAllUsers().catch((err) => {
+  console.error('Error deactivating users:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Added isActive property management to user Firestore records. Inactive users (missing isActive or isActive === false) are excluded from the leaderboard view. Users are automatically set to active upon logging in or fetching user info. Added an admin endpoint /user/deactivate-all, an Admin UI button, and a CLI script scripts/deactivate-all-users.js for resetting users at the start of a new season. Added unit test coverage for UserService and LeaderboardService.

---
*PR created automatically by Jules for task [6320443870943947144](https://jules.google.com/task/6320443870943947144) started by @joshknopp*